### PR TITLE
Add file organiser script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # self_organising_file_system
-An ateempt to automate the organisation of my files with clear guidelines and zero effort
+
+An attempt to automate the organisation of files with clear guidelines and zero effort.
+
+## Usage
+
+Run the organiser module with the directory you want to tidy:
+
+```bash
+python -m organiser /path/to/directory
+```
+
+The script sorts files into subfolders based on their extension. Unknown file types are moved into an `other` folder.

--- a/organiser/__init__.py
+++ b/organiser/__init__.py
@@ -1,0 +1,40 @@
+import shutil
+from pathlib import Path
+
+FILE_TYPES = {
+    "images": [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg"],
+    "documents": [".pdf", ".doc", ".docx", ".txt", ".md", ".ppt", ".pptx"],
+    "audio": [".mp3", ".wav", ".ogg"],
+    "video": [".mp4", ".mov", ".avi", ".mkv"],
+    "archives": [".zip", ".tar", ".gz", ".rar"],
+    "code": [".py", ".js", ".java", ".c", ".cpp", ".json", ".html", ".css"],
+}
+
+def categorize_file(file_path: Path) -> str:
+    """Return the category directory for a file based on its extension."""
+    ext = file_path.suffix.lower()
+    for category, extensions in FILE_TYPES.items():
+        if ext in extensions:
+            return category
+    return "other"
+
+def organise_directory(directory: Path) -> None:
+    """Organise files in the given directory into type-based folders."""
+    for item in directory.iterdir():
+        if item.is_file():
+            category = categorize_file(item)
+            target_dir = directory / category
+            target_dir.mkdir(exist_ok=True)
+            shutil.move(str(item), target_dir / item.name)
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Organise files in a directory by type")
+    parser.add_argument("path", type=Path, help="Directory to organise")
+    args = parser.parse_args()
+
+    if not args.path.exists() or not args.path.is_dir():
+        raise SystemExit(f"{args.path} is not a valid directory")
+
+    organise_directory(args.path)

--- a/tests/test_organiser.py
+++ b/tests/test_organiser.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+# Ensure the package root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import organiser
+
+def test_organise_directory(tmp_path):
+    # create files with different extensions
+    files = {
+        'image.jpg': 'images',
+        'doc.pdf': 'documents',
+        'song.mp3': 'audio',
+        'video.mp4': 'video',
+        'archive.zip': 'archives',
+        'script.py': 'code',
+        'note.xyz': 'other',
+    }
+    for name in files:
+        (tmp_path / name).write_text('data')
+
+    organiser.organise_directory(tmp_path)
+
+    for name, folder in files.items():
+        expected = tmp_path / folder / name
+        assert expected.exists(), f"{name} should be in {folder}"


### PR DESCRIPTION
## Summary
- add organiser module to sort files into type-based folders
- document usage and update README
- test organiser to ensure files move to proper directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68960273124c832e91500a0e9e22200d